### PR TITLE
Added MSVC-specific option to use the statically linked runtime library

### DIFF
--- a/cmake/PlatformWindowsMSVC.cmake
+++ b/cmake/PlatformWindowsMSVC.cmake
@@ -51,6 +51,12 @@ set(WIN32_COMPILE_FLAGS
                     #    /bigobj increases that address capacity to 4,294,967,296 (2^32).
 )
 
+option(OPTION_MSVC_STATIC_RUNTIME "Use statically linked C/C++ runtime library" OFF)
+if (OPTION_MSVC_STATIC_RUNTIME)
+  set(WIN32_COMPILE_FLAGS ${WIN32_COMPILE_FLAGS} $<$<CONFIG:Release>:/MT> $<$<CONFIG:Debug>:/MTd>)
+endif()
+
+
 # http://support.microsoft.com/kb/154419
 # "Programs that use the Standard C++ library must be compiled 
 #  with C++ exception handling enabled."


### PR DESCRIPTION
We want to use glbinding in our project, but we've had so much trouble with the plethory of MS runtime DLLs that our project lead decided years ago that they had to go. Since then, we're building all our modules with statically linked runtimes. This pull request add that option to glbinding.