### PR TITLE
Add GL_NONE_BIT (closes #59)

### DIFF
--- a/codegeneration/scripts/gen_bitfields.py
+++ b/codegeneration/scripts/gen_bitfields.py
@@ -96,11 +96,13 @@ def genFeatureBitfields(api, enums, feature, outputdir, outputfile, core = False
     
     if feature:
         importToNamespace = [ bitfieldImportDefinition(api, e) for e in sorted(pureBitfields) ]
-        importToNamespace.insert(0, "using gl::GL_NONE_BIT;")
+        if len(importToNamespace):
+            importToNamespace.insert(0, "using gl::GL_NONE_BIT;")
     else:
         groups = ", ".join([ qualifier+g for g in sorted(groupedBitfields.keys()) ])
         importToNamespace = [ forwardBitfield(api, e) for e in sorted(pureBitfields) ]
-        importToNamespace.insert(0, "static const glbinding::SharedBitfield<%s> GL_NONE_BIT = %s::%s::GL_NONE_BIT;" % (groups, api, groupedBitfields.keys()[0]))
+        if len(importToNamespace):
+            importToNamespace.insert(0, "static const glbinding::SharedBitfield<%s> GL_NONE_BIT = %s::%s::GL_NONE_BIT;" % (groups, api, sorted(groupedBitfields.keys())[0]))
 
     usedBitfsByName.clear()
     

--- a/codegeneration/scripts/gen_bitfields.py
+++ b/codegeneration/scripts/gen_bitfields.py
@@ -48,8 +48,12 @@ def bitfieldGroup(group, enums, usedBitfsByName):
 
     maxlen = max([len(enum.name) for enum in enums]) if len(enums) > 0 else 0
 
-    return bitfieldGroupTemplate % (group, "\n".join(
-        [ bitfieldDefinition(e, group, maxlen, usedBitfsByName) for e in enums ]))
+    enumGroupString = [ bitfieldDefinition(e, group, maxlen, usedBitfsByName) for e in enums ]
+    
+    spaces = " " * (maxlen - len("GL_NONE_BIT"))
+    enumGroupString.insert(0, "    GL_NONE_BIT " + spaces + "= 0x0, // Generic GL_NONE_BIT")
+    
+    return bitfieldGroupTemplate % (group, "\n".join(enumGroupString))
 
 
 def genBitfieldsAll(api, enums, outputdir, outputfile):
@@ -87,14 +91,16 @@ def genFeatureBitfields(api, enums, feature, outputdir, outputfile, core = False
     groupedBitfields = groupEnumsByGroup(pureBitfields)
 
     usedBitfsByName = dict()
-
-    #~ importToNamespace = [ ("\n// %s\n\n" + "%s") % (group, "\n".join(
-      #~ [ bitfieldImportDefinition(api, e, group, usedBitfsByName, feature) for e in values ])) 
-        #~ for group, values in sorted(groupedBitfields.items()) ]
+    
+    qualifier = api + "::"
+    
     if feature:
         importToNamespace = [ bitfieldImportDefinition(api, e) for e in sorted(pureBitfields) ]
+        importToNamespace.insert(0, "using gl::GL_NONE_BIT;")
     else:
+        groups = ", ".join([ qualifier+g for g in sorted(groupedBitfields.keys()) ])
         importToNamespace = [ forwardBitfield(api, e) for e in sorted(pureBitfields) ]
+        importToNamespace.insert(0, "static const glbinding::SharedBitfield<%s> GL_NONE_BIT = %s::%s::GL_NONE_BIT;" % (groups, api, groupedBitfields.keys()[0]))
 
     usedBitfsByName.clear()
     

--- a/source/glbinding/include/glbinding/SharedBitfield.h
+++ b/source/glbinding/include/glbinding/SharedBitfield.h
@@ -50,6 +50,8 @@ template <typename T>
 class SharedBitfieldBase
 {
 public:
+    using UnderlyingType = T;
+
     SharedBitfieldBase(T value);
 
     explicit operator T() const;
@@ -65,7 +67,10 @@ template <typename Type>
 class SharedBitfield<Type> : public SharedBitfieldBase<typename std::underlying_type<Type>::type>
 {
 public:
-    SharedBitfield(Type value);
+    using UnderlyingType = typename SharedBitfieldBase<typename std::underlying_type<Type>::type>::UnderlyingType;
+
+    template <typename ConstructionType>
+    SharedBitfield(ConstructionType value);
     SharedBitfield(typename std::underlying_type<Type>::type value);
 
     operator Type() const;
@@ -78,13 +83,22 @@ public:
 
     template <typename... T>
     auto operator^(SharedBitfield<T...> other) const -> typename std::enable_if<!std::is_same<typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type, SharedBitfield<>>::value, typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type>::type;
+
+    template <typename... T>
+    auto operator==(SharedBitfield<T...> other) const -> typename std::enable_if<!std::is_same<typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type, SharedBitfield<>>::value, bool>::type;
+
+    template <typename T>
+    auto operator==(T other) const -> typename std::enable_if<is_member_of_SharedBitfield<T, Type>::value, bool>::type;
 };
 
 template <typename Type, typename... Types>
 class SharedBitfield<Type, Types...> : public SharedBitfield<Types...>
 {
 public:
-    SharedBitfield(Type value);
+    using UnderlyingType = typename SharedBitfield<Types...>::UnderlyingType;
+
+    template <typename ConstructionType>
+    SharedBitfield(ConstructionType value);
     SharedBitfield(typename std::underlying_type<Type>::type value);
 
     operator Type() const;
@@ -97,6 +111,12 @@ public:
 
     template <typename... T>
     auto operator^(SharedBitfield<T...> other) const -> typename std::enable_if<!std::is_same<typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type, SharedBitfield<>>::value, typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type>::type;
+
+    template <typename... T>
+    auto operator==(SharedBitfield<T...> other) const -> typename std::enable_if<!std::is_same<typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type, SharedBitfield<>>::value, bool>::type;
+
+    template <typename T>
+    auto operator==(T other) const -> typename std::enable_if<is_member_of_SharedBitfield<T, Type, Types...>::value, bool>::type;
 };
 
 // operators

--- a/source/glbinding/include/glbinding/SharedBitfield.hpp
+++ b/source/glbinding/include/glbinding/SharedBitfield.hpp
@@ -19,9 +19,11 @@ SharedBitfieldBase<T>::operator T() const
 
 
 template <typename Type>
-SharedBitfield<Type>::SharedBitfield(Type value)
+template <typename ConstructionType>
+SharedBitfield<Type>::SharedBitfield(ConstructionType value)
 : SharedBitfieldBase<typename std::underlying_type<Type>::type>(static_cast<typename std::underlying_type<Type>::type>(value))
 {
+    static_assert(is_member_of_SharedBitfield<ConstructionType, Type>::value, "Not a member of SharedBitfield");
 }
 
 template <typename Type>
@@ -57,11 +59,27 @@ auto SharedBitfield<Type>::operator^(SharedBitfield<T...> other) const -> typena
     return typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type(this->m_value ^static_cast<decltype(this->m_value)>(other));
 }
 
+template <typename Type>
+template <typename... T>
+auto SharedBitfield<Type>::operator==(SharedBitfield<T...> other) const -> typename std::enable_if<!std::is_same<typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type, SharedBitfield<>>::value, bool>::type
+{
+    return static_cast<UnderlyingType>(*this) == static_cast<UnderlyingType>(other);
+}
+
+template <typename Type>
+template <typename T>
+auto SharedBitfield<Type>::operator==(T other) const -> typename std::enable_if<is_member_of_SharedBitfield<T, Type>::value, bool>::type
+{
+    return static_cast<UnderlyingType>(*this) == static_cast<UnderlyingType>(other);
+}
+
 
 template <typename Type, typename... Types>
-SharedBitfield<Type, Types...>::SharedBitfield(Type value)
+template <typename ConstructionType>
+SharedBitfield<Type, Types...>::SharedBitfield(ConstructionType value)
 : SharedBitfield<Types...>(static_cast<typename std::underlying_type<Type>::type>(value))
 {
+    static_assert(is_member_of_SharedBitfield<ConstructionType, Type, Types...>::value, "Not a member of SharedBitfield");
 }
 
 template <typename Type, typename... Types>
@@ -95,6 +113,20 @@ template <typename... T>
 auto SharedBitfield<Type, Types...>::operator^(SharedBitfield<T...> other) const -> typename std::enable_if<!std::is_same<typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type, SharedBitfield<>>::value, typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type>::type
 {
     return typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type(this->m_value ^static_cast<decltype(this->m_value)>(other));
+}
+
+template <typename Type, typename... Types>
+template <typename... T>
+auto SharedBitfield<Type, Types...>::operator==(SharedBitfield<T...> other) const -> typename std::enable_if<!std::is_same<typename intersect_SharedBitfield<SharedBitfield, SharedBitfield<T...>>::type, SharedBitfield<>>::value, bool>::type
+{
+    return static_cast<UnderlyingType>(*this) == static_cast<UnderlyingType>(other);
+}
+
+template <typename Type, typename... Types>
+template <typename T>
+auto SharedBitfield<Type, Types...>::operator==(T other) const -> typename std::enable_if<is_member_of_SharedBitfield<T, Type, Types...>::value, bool>::type
+{
+    return static_cast<UnderlyingType>(*this) == static_cast<UnderlyingType>(other);
 }
 
 

--- a/source/glbinding/include/glbinding/gl/bitfield.h
+++ b/source/glbinding/include/glbinding/gl/bitfield.h
@@ -302,7 +302,7 @@ enum class VertexHintsMaskPGI : unsigned int
 
 // import bitfields to namespace
 
-static const glbinding::SharedBitfield<gl::AttribMask, gl::BufferAccessMask, gl::BufferStorageMask, gl::ClearBufferMask, gl::ClientAttribMask, gl::ContextFlagMask, gl::ContextProfileMask, gl::FfdMaskSGIX, gl::FragmentShaderColorModMaskATI, gl::FragmentShaderDestMaskATI, gl::FragmentShaderDestModMaskATI, gl::MapBufferUsageMask, gl::MemoryBarrierMask, gl::PathFontStyle, gl::PathRenderingMaskNV, gl::PerformanceQueryCapsMaskINTEL, gl::SyncObjectMask, gl::TextureStorageMaskAMD, gl::UnusedMask, gl::UseProgramStageMask, gl::VertexHintsMaskPGI> GL_NONE_BIT = gl::BufferStorageMask::GL_NONE_BIT;
+static const glbinding::SharedBitfield<gl::AttribMask, gl::BufferAccessMask, gl::BufferStorageMask, gl::ClearBufferMask, gl::ClientAttribMask, gl::ContextFlagMask, gl::ContextProfileMask, gl::FfdMaskSGIX, gl::FragmentShaderColorModMaskATI, gl::FragmentShaderDestMaskATI, gl::FragmentShaderDestModMaskATI, gl::MapBufferUsageMask, gl::MemoryBarrierMask, gl::PathFontStyle, gl::PathRenderingMaskNV, gl::PerformanceQueryCapsMaskINTEL, gl::SyncObjectMask, gl::TextureStorageMaskAMD, gl::UnusedMask, gl::UseProgramStageMask, gl::VertexHintsMaskPGI> GL_NONE_BIT = gl::AttribMask::GL_NONE_BIT;
 static const PerformanceQueryCapsMaskINTEL GL_PERFQUERY_SINGLE_CONTEXT_INTEL = PerformanceQueryCapsMaskINTEL::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 static const UnusedMask GL_UNUSED_BIT = UnusedMask::GL_UNUSED_BIT;
 static const FragmentShaderDestModMaskATI GL_2X_BIT_ATI = FragmentShaderDestModMaskATI::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield.h
+++ b/source/glbinding/include/glbinding/gl/bitfield.h
@@ -9,6 +9,7 @@ namespace gl
 
 enum class AttribMask : unsigned int
 {
+    GL_NONE_BIT             = 0x0, // Generic GL_NONE_BIT
     GL_CURRENT_BIT          = 0x00000001,
     GL_POINT_BIT            = 0x00000002,
     GL_LINE_BIT             = 0x00000004,
@@ -39,6 +40,7 @@ enum class AttribMask : unsigned int
 
 enum class BufferAccessMask : unsigned int
 {
+    GL_NONE_BIT                  = 0x0, // Generic GL_NONE_BIT
     GL_MAP_READ_BIT              = 0x0001,
     GL_MAP_WRITE_BIT             = 0x0002,
     GL_MAP_INVALIDATE_RANGE_BIT  = 0x0004,
@@ -52,6 +54,7 @@ enum class BufferAccessMask : unsigned int
 
 enum class BufferStorageMask : unsigned int
 {
+    GL_NONE_BIT            = 0x0, // Generic GL_NONE_BIT
     GL_MAP_READ_BIT        = 0x0001, // reuse from BufferAccessMask
     GL_MAP_WRITE_BIT       = 0x0002, // reuse from BufferAccessMask
     GL_MAP_PERSISTENT_BIT  = 0x0040, // reuse from BufferAccessMask
@@ -63,6 +66,7 @@ enum class BufferStorageMask : unsigned int
 
 enum class ClearBufferMask : unsigned int
 {
+    GL_NONE_BIT               = 0x0, // Generic GL_NONE_BIT
     GL_DEPTH_BUFFER_BIT       = 0x00000100, // reuse from AttribMask
     GL_ACCUM_BUFFER_BIT       = 0x00000200, // reuse from AttribMask
     GL_STENCIL_BUFFER_BIT     = 0x00000400, // reuse from AttribMask
@@ -73,6 +77,7 @@ enum class ClearBufferMask : unsigned int
 
 enum class ClientAttribMask : unsigned int
 {
+    GL_NONE_BIT                = 0x0, // Generic GL_NONE_BIT
     GL_CLIENT_PIXEL_STORE_BIT  = 0x00000001,
     GL_CLIENT_VERTEX_ARRAY_BIT = 0x00000002,
     GL_CLIENT_ALL_ATTRIB_BITS  = 0xFFFFFFFF,
@@ -81,6 +86,7 @@ enum class ClientAttribMask : unsigned int
 
 enum class ContextFlagMask : unsigned int
 {
+    GL_NONE_BIT                            = 0x0, // Generic GL_NONE_BIT
     GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT = 0x00000001,
     GL_CONTEXT_FLAG_DEBUG_BIT              = 0x00000002,
     GL_CONTEXT_FLAG_ROBUST_ACCESS_BIT      = 0x00000004,
@@ -90,6 +96,7 @@ enum class ContextFlagMask : unsigned int
 
 enum class ContextProfileMask : unsigned int
 {
+    GL_NONE_BIT                          = 0x0, // Generic GL_NONE_BIT
     GL_CONTEXT_CORE_PROFILE_BIT          = 0x00000001,
     GL_CONTEXT_COMPATIBILITY_PROFILE_BIT = 0x00000002,
 };
@@ -97,6 +104,7 @@ enum class ContextProfileMask : unsigned int
 
 enum class FfdMaskSGIX : unsigned int
 {
+    GL_NONE_BIT                      = 0x0, // Generic GL_NONE_BIT
     GL_TEXTURE_DEFORMATION_BIT_SGIX  = 0x00000001,
     GL_GEOMETRY_DEFORMATION_BIT_SGIX = 0x00000002,
 };
@@ -104,6 +112,7 @@ enum class FfdMaskSGIX : unsigned int
 
 enum class FragmentShaderColorModMaskATI : unsigned int
 {
+    GL_NONE_BIT       = 0x0, // Generic GL_NONE_BIT
     GL_COMP_BIT_ATI   = 0x00000002,
     GL_NEGATE_BIT_ATI = 0x00000004,
     GL_BIAS_BIT_ATI   = 0x00000008,
@@ -112,6 +121,7 @@ enum class FragmentShaderColorModMaskATI : unsigned int
 
 enum class FragmentShaderDestMaskATI : unsigned int
 {
+    GL_NONE_BIT      = 0x0, // Generic GL_NONE_BIT
     GL_RED_BIT_ATI   = 0x00000001,
     GL_GREEN_BIT_ATI = 0x00000002,
     GL_BLUE_BIT_ATI  = 0x00000004,
@@ -120,6 +130,7 @@ enum class FragmentShaderDestMaskATI : unsigned int
 
 enum class FragmentShaderDestModMaskATI : unsigned int
 {
+    GL_NONE_BIT         = 0x0, // Generic GL_NONE_BIT
     GL_2X_BIT_ATI       = 0x00000001,
     GL_4X_BIT_ATI       = 0x00000002,
     GL_8X_BIT_ATI       = 0x00000004,
@@ -132,6 +143,7 @@ enum class FragmentShaderDestModMaskATI : unsigned int
 
 enum class MapBufferUsageMask : unsigned int
 {
+    GL_NONE_BIT                  = 0x0, // Generic GL_NONE_BIT
     GL_MAP_READ_BIT              = 0x0001, // reuse from BufferAccessMask
     GL_MAP_WRITE_BIT             = 0x0002, // reuse from BufferAccessMask
     GL_MAP_INVALIDATE_RANGE_BIT  = 0x0004, // reuse from BufferAccessMask
@@ -148,6 +160,7 @@ enum class MapBufferUsageMask : unsigned int
 
 enum class MemoryBarrierMask : unsigned int
 {
+    GL_NONE_BIT                            = 0x0, // Generic GL_NONE_BIT
     GL_VERTEX_ATTRIB_ARRAY_BARRIER_BIT     = 0x00000001,
     GL_VERTEX_ATTRIB_ARRAY_BARRIER_BIT_EXT = 0x00000001,
     GL_ELEMENT_ARRAY_BARRIER_BIT           = 0x00000002,
@@ -183,6 +196,7 @@ enum class MemoryBarrierMask : unsigned int
 
 enum class PathFontStyle : unsigned int
 {
+    GL_NONE_BIT      = 0x0, // Generic GL_NONE_BIT
     GL_BOLD_BIT_NV   = 0x01,
     GL_ITALIC_BIT_NV = 0x02,
 };
@@ -190,6 +204,7 @@ enum class PathFontStyle : unsigned int
 
 enum class PathRenderingMaskNV : unsigned int
 {
+    GL_NONE_BIT                                = 0x0, // Generic GL_NONE_BIT
     GL_FONT_X_MIN_BOUNDS_BIT_NV                = 0x00010000,
     GL_FONT_Y_MIN_BOUNDS_BIT_NV                = 0x00020000,
     GL_FONT_X_MAX_BOUNDS_BIT_NV                = 0x00040000,
@@ -220,6 +235,7 @@ enum class PathRenderingMaskNV : unsigned int
 
 enum class PerformanceQueryCapsMaskINTEL : unsigned int
 {
+    GL_NONE_BIT                       = 0x0, // Generic GL_NONE_BIT
     GL_PERFQUERY_SINGLE_CONTEXT_INTEL = 0x00000000,
     GL_PERFQUERY_GLOBAL_CONTEXT_INTEL = 0x00000001,
 };
@@ -227,24 +243,28 @@ enum class PerformanceQueryCapsMaskINTEL : unsigned int
 
 enum class SyncObjectMask : unsigned int
 {
+    GL_NONE_BIT                = 0x0, // Generic GL_NONE_BIT
     GL_SYNC_FLUSH_COMMANDS_BIT = 0x00000001,
 };
 
 
 enum class TextureStorageMaskAMD : unsigned int
 {
+    GL_NONE_BIT                       = 0x0, // Generic GL_NONE_BIT
     GL_TEXTURE_STORAGE_SPARSE_BIT_AMD = 0x00000001,
 };
 
 
 enum class UnusedMask : unsigned int
 {
+    GL_NONE_BIT   = 0x0, // Generic GL_NONE_BIT
     GL_UNUSED_BIT = 0x00000000,
 };
 
 
 enum class UseProgramStageMask : unsigned int
 {
+    GL_NONE_BIT                   = 0x0, // Generic GL_NONE_BIT
     GL_VERTEX_SHADER_BIT          = 0x00000001,
     GL_FRAGMENT_SHADER_BIT        = 0x00000002,
     GL_GEOMETRY_SHADER_BIT        = 0x00000004,
@@ -257,6 +277,7 @@ enum class UseProgramStageMask : unsigned int
 
 enum class VertexHintsMaskPGI : unsigned int
 {
+    GL_NONE_BIT                        = 0x0, // Generic GL_NONE_BIT
     GL_VERTEX23_BIT_PGI                = 0x00000004,
     GL_VERTEX4_BIT_PGI                 = 0x00000008,
     GL_COLOR3_BIT_PGI                  = 0x00010000,
@@ -281,6 +302,7 @@ enum class VertexHintsMaskPGI : unsigned int
 
 // import bitfields to namespace
 
+static const glbinding::SharedBitfield<gl::AttribMask, gl::BufferAccessMask, gl::BufferStorageMask, gl::ClearBufferMask, gl::ClientAttribMask, gl::ContextFlagMask, gl::ContextProfileMask, gl::FfdMaskSGIX, gl::FragmentShaderColorModMaskATI, gl::FragmentShaderDestMaskATI, gl::FragmentShaderDestModMaskATI, gl::MapBufferUsageMask, gl::MemoryBarrierMask, gl::PathFontStyle, gl::PathRenderingMaskNV, gl::PerformanceQueryCapsMaskINTEL, gl::SyncObjectMask, gl::TextureStorageMaskAMD, gl::UnusedMask, gl::UseProgramStageMask, gl::VertexHintsMaskPGI> GL_NONE_BIT = gl::BufferStorageMask::GL_NONE_BIT;
 static const PerformanceQueryCapsMaskINTEL GL_PERFQUERY_SINGLE_CONTEXT_INTEL = PerformanceQueryCapsMaskINTEL::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 static const UnusedMask GL_UNUSED_BIT = UnusedMask::GL_UNUSED_BIT;
 static const FragmentShaderDestModMaskATI GL_2X_BIT_ATI = FragmentShaderDestModMaskATI::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield10.h
+++ b/source/glbinding/include/glbinding/gl/bitfield10.h
@@ -8,6 +8,6 @@ namespace gl10
 {
 
 // import bitfields to namespace
-
+using gl::GL_NONE_BIT;
 
 } // namespace gl10

--- a/source/glbinding/include/glbinding/gl/bitfield10.h
+++ b/source/glbinding/include/glbinding/gl/bitfield10.h
@@ -8,6 +8,6 @@ namespace gl10
 {
 
 // import bitfields to namespace
-using gl::GL_NONE_BIT;
+
 
 } // namespace gl10

--- a/source/glbinding/include/glbinding/gl/bitfield10ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield10ext.h
@@ -8,6 +8,7 @@ namespace gl10ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield11.h
+++ b/source/glbinding/include/glbinding/gl/bitfield11.h
@@ -8,6 +8,7 @@ namespace gl11
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CURRENT_BIT;
 using gl::GL_CLIENT_VERTEX_ARRAY_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield11ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield11ext.h
@@ -8,6 +8,7 @@ namespace gl11ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield12.h
+++ b/source/glbinding/include/glbinding/gl/bitfield12.h
@@ -8,6 +8,7 @@ namespace gl12
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CURRENT_BIT;
 using gl::GL_CLIENT_VERTEX_ARRAY_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield12ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield12ext.h
@@ -8,6 +8,7 @@ namespace gl12ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield13.h
+++ b/source/glbinding/include/glbinding/gl/bitfield13.h
@@ -8,6 +8,7 @@ namespace gl13
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CURRENT_BIT;
 using gl::GL_CLIENT_VERTEX_ARRAY_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield13ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield13ext.h
@@ -8,6 +8,7 @@ namespace gl13ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield14.h
+++ b/source/glbinding/include/glbinding/gl/bitfield14.h
@@ -8,6 +8,7 @@ namespace gl14
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CURRENT_BIT;
 using gl::GL_CLIENT_VERTEX_ARRAY_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield14ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield14ext.h
@@ -8,6 +8,7 @@ namespace gl14ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield15.h
+++ b/source/glbinding/include/glbinding/gl/bitfield15.h
@@ -8,6 +8,7 @@ namespace gl15
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CURRENT_BIT;
 using gl::GL_CLIENT_VERTEX_ARRAY_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield15ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield15ext.h
@@ -8,6 +8,7 @@ namespace gl15ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield20.h
+++ b/source/glbinding/include/glbinding/gl/bitfield20.h
@@ -8,6 +8,7 @@ namespace gl20
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CURRENT_BIT;
 using gl::GL_CLIENT_VERTEX_ARRAY_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield20ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield20ext.h
@@ -8,6 +8,7 @@ namespace gl20ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield21.h
+++ b/source/glbinding/include/glbinding/gl/bitfield21.h
@@ -8,6 +8,7 @@ namespace gl21
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CURRENT_BIT;
 using gl::GL_CLIENT_VERTEX_ARRAY_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield21ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield21ext.h
@@ -8,6 +8,7 @@ namespace gl21ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield30.h
+++ b/source/glbinding/include/glbinding/gl/bitfield30.h
@@ -8,6 +8,7 @@ namespace gl30
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;
 using gl::GL_CURRENT_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield30ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield30ext.h
@@ -8,6 +8,7 @@ namespace gl30ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield31.h
+++ b/source/glbinding/include/glbinding/gl/bitfield31.h
@@ -8,6 +8,7 @@ namespace gl31
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;
 using gl::GL_CURRENT_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield31ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield31ext.h
@@ -8,6 +8,7 @@ namespace gl31ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield32.h
+++ b/source/glbinding/include/glbinding/gl/bitfield32.h
@@ -8,6 +8,7 @@ namespace gl32
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield32core.h
+++ b/source/glbinding/include/glbinding/gl/bitfield32core.h
@@ -8,6 +8,7 @@ namespace gl32core
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;
 using gl::GL_SYNC_FLUSH_COMMANDS_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield32ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield32ext.h
@@ -8,6 +8,7 @@ namespace gl32ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield33.h
+++ b/source/glbinding/include/glbinding/gl/bitfield33.h
@@ -8,6 +8,7 @@ namespace gl33
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield33core.h
+++ b/source/glbinding/include/glbinding/gl/bitfield33core.h
@@ -8,6 +8,7 @@ namespace gl33core
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;
 using gl::GL_SYNC_FLUSH_COMMANDS_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield33ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield33ext.h
@@ -8,6 +8,7 @@ namespace gl33ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield40.h
+++ b/source/glbinding/include/glbinding/gl/bitfield40.h
@@ -8,6 +8,7 @@ namespace gl40
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield40core.h
+++ b/source/glbinding/include/glbinding/gl/bitfield40core.h
@@ -8,6 +8,7 @@ namespace gl40core
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;
 using gl::GL_SYNC_FLUSH_COMMANDS_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield40ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield40ext.h
@@ -8,6 +8,7 @@ namespace gl40ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield41.h
+++ b/source/glbinding/include/glbinding/gl/bitfield41.h
@@ -8,6 +8,7 @@ namespace gl41
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield41core.h
+++ b/source/glbinding/include/glbinding/gl/bitfield41core.h
@@ -8,6 +8,7 @@ namespace gl41core
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;
 using gl::GL_SYNC_FLUSH_COMMANDS_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield41ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield41ext.h
@@ -8,6 +8,7 @@ namespace gl41ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield42.h
+++ b/source/glbinding/include/glbinding/gl/bitfield42.h
@@ -8,6 +8,7 @@ namespace gl42
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield42core.h
+++ b/source/glbinding/include/glbinding/gl/bitfield42core.h
@@ -8,6 +8,7 @@ namespace gl42core
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;
 using gl::GL_SYNC_FLUSH_COMMANDS_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield42ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield42ext.h
@@ -8,6 +8,7 @@ namespace gl42ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield43.h
+++ b/source/glbinding/include/glbinding/gl/bitfield43.h
@@ -8,6 +8,7 @@ namespace gl43
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield43core.h
+++ b/source/glbinding/include/glbinding/gl/bitfield43core.h
@@ -8,6 +8,7 @@ namespace gl43core
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;
 using gl::GL_SYNC_FLUSH_COMMANDS_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield43ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield43ext.h
@@ -8,6 +8,7 @@ namespace gl43ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield44.h
+++ b/source/glbinding/include/glbinding/gl/bitfield44.h
@@ -8,6 +8,7 @@ namespace gl44
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield44core.h
+++ b/source/glbinding/include/glbinding/gl/bitfield44core.h
@@ -8,6 +8,7 @@ namespace gl44core
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;
 using gl::GL_SYNC_FLUSH_COMMANDS_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield44ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield44ext.h
@@ -8,6 +8,7 @@ namespace gl44ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/glbinding/include/glbinding/gl/bitfield45.h
+++ b/source/glbinding/include/glbinding/gl/bitfield45.h
@@ -8,6 +8,7 @@ namespace gl45
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CLIENT_PIXEL_STORE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield45core.h
+++ b/source/glbinding/include/glbinding/gl/bitfield45core.h
@@ -8,6 +8,7 @@ namespace gl45core
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_CONTEXT_CORE_PROFILE_BIT;
 using gl::GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;
 using gl::GL_SYNC_FLUSH_COMMANDS_BIT;

--- a/source/glbinding/include/glbinding/gl/bitfield45ext.h
+++ b/source/glbinding/include/glbinding/gl/bitfield45ext.h
@@ -8,6 +8,7 @@ namespace gl45ext
 {
 
 // import bitfields to namespace
+using gl::GL_NONE_BIT;
 using gl::GL_PERFQUERY_SINGLE_CONTEXT_INTEL;
 using gl::GL_UNUSED_BIT;
 using gl::GL_2X_BIT_ATI;

--- a/source/tests/glbinding-test/CMakeLists.txt
+++ b/source/tests/glbinding-test/CMakeLists.txt
@@ -54,6 +54,7 @@ set(sources
     RingBuffer_test.cpp
     ${glbinding_source_path}/RingBuffer.h
     ${glbinding_source_path}/RingBuffer.hpp
+    SharedBitfield_test.cpp
     # regession test
     Regression_test_82.cpp
 )

--- a/source/tests/glbinding-test/RingBuffer_test.cpp
+++ b/source/tests/glbinding-test/RingBuffer_test.cpp
@@ -18,26 +18,26 @@ public:
 TEST_F(RingBuffer_test, SimpleTest)
 {
     RingBuffer<int> buffer(10);
-    EXPECT_EQ(10, buffer.maxSize());
+    EXPECT_EQ(10u, buffer.maxSize());
     EXPECT_EQ(true, buffer.isEmpty());
 
     RingBuffer<int>::TailIdentifier tail = buffer.addTail();
     auto it = buffer.cbegin(tail);
-    EXPECT_EQ(false, buffer.valid(tail, it));
-    EXPECT_EQ(0, buffer.size(tail));
-    EXPECT_EQ(0, buffer.size());
+    EXPECT_FALSE(buffer.valid(tail, it));
+    EXPECT_EQ(0u, buffer.size(tail));
+    EXPECT_EQ(0u, buffer.size());
 
     for (int i = 0; i < 10; i++)
     {
         EXPECT_EQ(true, buffer.push(i));
     }
 
-    EXPECT_EQ(10, buffer.size());
-    EXPECT_EQ(10, buffer.size(tail));
-    EXPECT_EQ(false, buffer.push(11));
-    EXPECT_EQ(true, buffer.isFull());
+    EXPECT_EQ(10u, buffer.size());
+    EXPECT_EQ(10u, buffer.size(tail));
+    EXPECT_FALSE(buffer.push(11));
+    EXPECT_TRUE(buffer.isFull());
 
-    EXPECT_EQ(true, buffer.valid(tail, it));
+    EXPECT_TRUE(buffer.valid(tail, it));
 
     for (int i = 0; i < 5; i++)
     {
@@ -48,14 +48,14 @@ TEST_F(RingBuffer_test, SimpleTest)
         EXPECT_EQ(buffer.size(tail), buffer.size());
     }
 
-    EXPECT_EQ(5, buffer.size());
+    EXPECT_EQ(5u, buffer.size());
 
     for (int i = 10; i < 15; i++)
     {
         EXPECT_EQ(true, buffer.push(i));
     }
 
-    EXPECT_EQ(10, buffer.size());
+    EXPECT_EQ(10u, buffer.size());
 
     for (int i = 5; i < 15; i++)
     {
@@ -78,17 +78,17 @@ TEST_F(RingBuffer_test, SimpleTest)
         EXPECT_EQ(buffer.size(tail), buffer.size());
     }
 
-    EXPECT_EQ(2, buffer.size());
+    EXPECT_EQ(2u, buffer.size());
 
     buffer.removeTail(tail);
-    EXPECT_EQ(2, buffer.size());
+    EXPECT_EQ(2u, buffer.size());
 }
 
 TEST_F(RingBuffer_test, StringTest)
 {
     RingBuffer<std::string> buffer(10);
-    EXPECT_EQ(10, buffer.maxSize());
-    EXPECT_EQ(true, buffer.isEmpty());
+    EXPECT_EQ(10u, buffer.maxSize());
+    EXPECT_TRUE(buffer.isEmpty());
 
     RingBuffer<int>::TailIdentifier tail = buffer.addTail();
 
@@ -112,8 +112,8 @@ TEST_F(RingBuffer_test, StringTest)
         EXPECT_EQ(buffer.size(tail), buffer.size());
     }
 
-    EXPECT_EQ(0, buffer.size());
-    EXPECT_EQ(false, buffer.valid(tail, it));
+    EXPECT_EQ(0u, buffer.size());
+    EXPECT_FALSE(buffer.valid(tail, it));
 }
 
 // Test behavior with objects
@@ -125,8 +125,8 @@ struct MockObject {
 TEST_F(RingBuffer_test, ObjectTest)
 {
     RingBuffer<MockObject> buffer(10);
-    EXPECT_EQ(10, buffer.maxSize());
-    EXPECT_EQ(true, buffer.isEmpty());
+    EXPECT_EQ(10u, buffer.maxSize());
+    EXPECT_TRUE(buffer.isEmpty());
 
     int i0 = 0;
     MockObject obj0 = {0, &i0};
@@ -159,15 +159,15 @@ TEST_F(RingBuffer_test, ObjectTest)
         EXPECT_EQ(buffer.size(tail), buffer.size());
     }
 
-    EXPECT_EQ(0, buffer.size());
-    EXPECT_EQ(false, buffer.valid(tail, it));    
+    EXPECT_EQ(0u, buffer.size());
+    EXPECT_FALSE(buffer.valid(tail, it));
 }
 
 TEST_F(RingBuffer_test, ObjectPointerTest)
 {
     RingBuffer<MockObject*> buffer(10);
-    EXPECT_EQ(10, buffer.maxSize());
-    EXPECT_EQ(true, buffer.isEmpty());
+    EXPECT_EQ(10u, buffer.maxSize());
+    EXPECT_TRUE(buffer.isEmpty());
 
     int i0 = 0;
     MockObject obj0 = {0, &i0};
@@ -200,8 +200,8 @@ TEST_F(RingBuffer_test, ObjectPointerTest)
         EXPECT_EQ(buffer.size(tail), buffer.size());
     }
 
-    EXPECT_EQ(0, buffer.size());
-    EXPECT_EQ(false, buffer.valid(tail, it));    
+    EXPECT_EQ(0u, buffer.size());
+    EXPECT_FALSE(buffer.valid(tail, it));
 }
 
 TEST_F(RingBuffer_test, SimpleMultiThreadedTest)
@@ -232,12 +232,12 @@ TEST_F(RingBuffer_test, SimpleMultiThreadedTest)
 
         }
 
-        EXPECT_EQ(0, buffer.size(tail));
+        EXPECT_EQ(0u, buffer.size(tail));
     });
 
     t1.join();
     t2.join();
-    EXPECT_EQ(0, buffer.size());
+    EXPECT_EQ(0u, buffer.size());
 }
 
 TEST_F(RingBuffer_test, MultiThreadedTest2)
@@ -269,7 +269,7 @@ TEST_F(RingBuffer_test, MultiThreadedTest2)
 
         }
 
-        EXPECT_EQ(0, buffer.size(tail1));
+        EXPECT_EQ(0u, buffer.size(tail1));
     });
 
     std::thread t3([&]()
@@ -287,13 +287,13 @@ TEST_F(RingBuffer_test, MultiThreadedTest2)
 
         }
 
-        EXPECT_EQ(0, buffer.size(tail2));
+        EXPECT_EQ(0u, buffer.size(tail2));
     });
 
     t1.join();
     t2.join();
     t3.join();
-    EXPECT_EQ(0, buffer.size());
+    EXPECT_EQ(0u, buffer.size());
 }
 
 

--- a/source/tests/glbinding-test/SharedBitfield_test.cpp
+++ b/source/tests/glbinding-test/SharedBitfield_test.cpp
@@ -1,0 +1,66 @@
+
+#include <gmock/gmock.h>
+
+#include <glbinding/SharedBitfield.h>
+
+using namespace glbinding;
+
+enum class A
+{
+    A_a,
+    A_b,
+    A_c
+};
+
+enum class B
+{
+    B_a,
+    B_b,
+    B_c
+};
+
+enum class C
+{
+    C_a,
+    C_b,
+    C_c
+};
+
+TEST(SharedBitfield, Instantiation)
+{
+    SharedBitfield<A, B, C> bitsA_a = A::A_a;
+    SharedBitfield<A, B, C> bitsA_b = A::A_b;
+    SharedBitfield<A, B, C> bitsA_c = A::A_c;
+    SharedBitfield<A, B, C> bitsB_a = B::B_a;
+    SharedBitfield<A, B, C> bitsB_b = B::B_b;
+    SharedBitfield<A, B, C> bitsB_c = B::B_c;
+    SharedBitfield<A, B, C> bitsC_a = C::C_a;
+    SharedBitfield<A, B, C> bitsC_b = C::C_b;
+    SharedBitfield<A, B, C> bitsC_c = C::C_c;
+
+    EXPECT_EQ(bitsA_a, A::A_a);
+    EXPECT_EQ(bitsB_a, C::C_a);
+    EXPECT_EQ(bitsA_b, C::C_b);
+    EXPECT_EQ(bitsB_b, B::B_b);
+    EXPECT_EQ(bitsA_c, A::A_c);
+    EXPECT_EQ(bitsB_c, C::C_c);
+
+    EXPECT_EQ(A::A_a, bitsA_a);
+    EXPECT_EQ(C::C_a, bitsB_a);
+    EXPECT_EQ(C::C_b, bitsA_b);
+    EXPECT_EQ(B::B_b, bitsB_b);
+    EXPECT_EQ(A::A_c, bitsA_c);
+    EXPECT_EQ(C::C_c, bitsB_c);
+
+    EXPECT_EQ(bitsA_a, bitsB_a);
+    EXPECT_EQ(bitsB_a, bitsC_a);
+    EXPECT_EQ(bitsA_b, bitsB_b);
+    EXPECT_EQ(bitsB_b, bitsC_b);
+    EXPECT_EQ(bitsA_c, bitsB_c);
+    EXPECT_EQ(bitsB_c, bitsC_c);
+
+    bitsC_c = bitsC_a;
+    bitsC_b = B::B_b;
+
+    SUCCEED();  // compiling this file results in successful test
+}

--- a/source/tests/glbinding-test/SharedBitfield_test.cpp
+++ b/source/tests/glbinding-test/SharedBitfield_test.cpp
@@ -26,7 +26,7 @@ enum class C
     C_c
 };
 
-TEST(SharedBitfield, Instantiation)
+TEST(SharedBitfield, Usage)
 {
     SharedBitfield<A, B, C> bitsA_a = A::A_a;
     SharedBitfield<A, B, C> bitsA_b = A::A_b;
@@ -61,6 +61,4 @@ TEST(SharedBitfield, Instantiation)
 
     bitsC_c = bitsC_a;
     bitsC_b = B::B_b;
-
-    SUCCEED();  // compiling this file results in successful test
 }


### PR DESCRIPTION
Adds a generic ```GL_NONE_BIT``` that equals to no bit set for all bitfield groups.