### PR TITLE
Logging Improvements

### DIFF
--- a/source/examples/comparison/main.cpp
+++ b/source/examples/comparison/main.cpp
@@ -89,14 +89,14 @@ void compare()
     glbinding_error(false);
 
     std::cout << std::endl << "test: again, now with logging ..." << std::endl;
-    glbinding::logging::log(true);
+    glbinding::logging::start("logs/comparison");
     timer.start("      glbinding ");
 
     for (int i = 0; i < ITERATIONS; ++i)
         glbinding_test();
     
     long double glbinding_avg_log = timer.stop();
-    glbinding::logging::log(false);
+    glbinding::logging::stop();
 
 
     std::cout << std::endl << "glbinding/glew decrease:                 " << (glbinding_avg / glew_avg - 1.0) * 100.0 << "%" << std::endl;

--- a/source/glbinding/include/glbinding/callbacks.h
+++ b/source/glbinding/include/glbinding/callbacks.h
@@ -54,6 +54,7 @@ GLBINDING_API CallbackMask& operator&=(CallbackMask& a, CallbackMask b);
 GLBINDING_API void setCallbackMask(CallbackMask mask);
 GLBINDING_API void setCallbackMaskExcept(CallbackMask mask, const std::set<std::string> & blackList);
 GLBINDING_API void addCallbackMask(CallbackMask mask);
+GLBINDING_API void addCallbackMaskExcept(CallbackMask mask, const std::set<std::string> & blackList);
 GLBINDING_API void removeCallbackMask(CallbackMask mask);
 
 using SimpleFunctionCallback = std::function<void(const AbstractFunction &)>;

--- a/source/glbinding/include/glbinding/logging.h
+++ b/source/glbinding/include/glbinding/logging.h
@@ -1,15 +1,10 @@
 #pragma once
 
-#include <glbinding/AbstractValue.h> 
 #include <glbinding/callbacks.h>
 
 
 namespace glbinding 
 {
-
-template <typename T>
-class RingBuffer;
-
 
 namespace logging
 {
@@ -18,19 +13,9 @@ namespace logging
     GLBINDING_API void stop();
     GLBINDING_API void pause();
     GLBINDING_API void resume();
-    GLBINDING_API void log(bool enable);
 
     using BufferType = FunctionCall*;
     GLBINDING_API void log(BufferType  call);
-
-
-    using TailIdentifier = unsigned int;
-    GLBINDING_API TailIdentifier addTail();
-    GLBINDING_API void removeTail(TailIdentifier);
-    GLBINDING_API const std::vector<BufferType>::const_iterator cbegin(TailIdentifier key);
-    GLBINDING_API bool valid(TailIdentifier key, const std::vector<BufferType>::const_iterator & it);
-    GLBINDING_API const std::vector<BufferType>::const_iterator next(TailIdentifier key, const std::vector<BufferType>::const_iterator & it);
-    GLBINDING_API unsigned int size(TailIdentifier key);
 }
 
 

--- a/source/glbinding/include/glbinding/logging.h
+++ b/source/glbinding/include/glbinding/logging.h
@@ -8,6 +8,8 @@ namespace glbinding
 
 namespace logging
 {
+    GLBINDING_API void resize(const unsigned int);
+
     GLBINDING_API void start();
     GLBINDING_API void start(const std::string & filepath);
     GLBINDING_API void stop();

--- a/source/glbinding/include/glbinding/logging.h
+++ b/source/glbinding/include/glbinding/logging.h
@@ -12,6 +12,8 @@ namespace logging
 
     GLBINDING_API void start();
     GLBINDING_API void start(const std::string & filepath);
+    GLBINDING_API void startExcept(const std::set<std::string> & blackList);
+    GLBINDING_API void startExcept(const std::string & filepath, const std::set<std::string> & blackList);
     GLBINDING_API void stop();
     GLBINDING_API void pause();
     GLBINDING_API void resume();

--- a/source/glbinding/source/RingBuffer.h
+++ b/source/glbinding/source/RingBuffer.h
@@ -17,9 +17,9 @@ public:
     using SizeType = unsigned int;
     RingBuffer(SizeType maxSize);
 
-    T nextHead();
-    bool push(T &&);
-    bool push(T &);
+    T nextHead(bool & available);
+    bool push(T && entry);
+    bool push(T & entry);
 
     using TailIdentifier = unsigned int;
     TailIdentifier addTail();

--- a/source/glbinding/source/RingBuffer.h
+++ b/source/glbinding/source/RingBuffer.h
@@ -17,6 +17,8 @@ public:
     using SizeType = unsigned int;
     RingBuffer(SizeType maxSize);
 
+    void resize(SizeType newSize);
+
     T nextHead(bool & available);
     bool push(T && entry);
     bool push(T & entry);
@@ -42,7 +44,7 @@ protected:
 
 protected:
     std::vector<T> m_buffer;
-    const SizeType m_size;
+    SizeType m_size;
     std::atomic<SizeType> m_head;
     std::map<TailIdentifier, std::atomic<SizeType>> m_tails;
 };

--- a/source/glbinding/source/RingBuffer.hpp
+++ b/source/glbinding/source/RingBuffer.hpp
@@ -19,6 +19,13 @@ RingBuffer<T>::RingBuffer(const unsigned int maxSize)
 }
 
 template <typename T>
+void RingBuffer<T>::resize(const unsigned int newSize)
+{
+    m_size = newSize + 1;
+    m_buffer.resize(m_size);
+}
+
+template <typename T>
 T RingBuffer<T>::nextHead(bool & available)
 {
     auto head = m_head.load(std::memory_order_relaxed);

--- a/source/glbinding/source/callbacks.cpp
+++ b/source/glbinding/source/callbacks.cpp
@@ -75,17 +75,17 @@ CallbackMask& operator&=(CallbackMask& a, CallbackMask b)
 
 std::string FunctionCall::toString() const
 {   
-    using nanoseconds = std::chrono::nanoseconds;
-    nanoseconds now_ns = std::chrono::duration_cast<nanoseconds>(timestamp.time_since_epoch());
-    std::size_t ns = now_ns.count() % 1000;
-    std::ostringstream ns_os;
-    ns_os << std::setfill('0') << std::setw(3) << ns;
+    using microseconds = std::chrono::microseconds;
+    microseconds now_micros = std::chrono::duration_cast<microseconds>(timestamp.time_since_epoch());
+    std::size_t micros = now_micros.count() % 1000;
+    std::ostringstream micros_os;
+    micros_os << std::setfill('0') << std::setw(3) << micros;
 
     using milliseconds = std::chrono::milliseconds;
-    milliseconds now_ms = std::chrono::duration_cast<milliseconds>(now_ns);
-    std::size_t ms = now_ms.count() % 1000;
-    std::ostringstream ms_os;
-    ms_os << std::setfill('0') << std::setw(3) << ms;
+    milliseconds now_millis = std::chrono::duration_cast<milliseconds>(now_micros);
+    std::size_t millis = now_millis.count() % 1000;
+    std::ostringstream millis_os;
+    millis_os << std::setfill('0') << std::setw(3) << millis;
 
     auto t = std::chrono::system_clock::to_time_t(timestamp);
     char time_string[20];
@@ -93,7 +93,7 @@ std::string FunctionCall::toString() const
 
     std::ostringstream os;
 
-    os << time_string << ":" << ms_os.str() << ":" << ns_os.str() << " ";
+    os << time_string << ":" << millis_os.str() << ":" << micros_os.str() << " ";
     os << function->name() << "(";
 
     for (unsigned i = 0; i < parameters.size(); ++i)

--- a/source/glbinding/source/callbacks.cpp
+++ b/source/glbinding/source/callbacks.cpp
@@ -142,6 +142,17 @@ void addCallbackMask(const CallbackMask mask)
     }
 }
 
+void addCallbackMaskExcept(const CallbackMask mask, const std::set<std::string> & blackList)
+{
+    for (AbstractFunction * function : Binding::functions())
+    {
+        if (blackList.find(function->name()) == blackList.end())
+        {
+            function->addCallbackMask(mask);
+        }
+    }
+}
+
 void removeCallbackMask(const CallbackMask mask)
 {
     for (AbstractFunction * function : Binding::functions())

--- a/source/glbinding/source/logging.cpp
+++ b/source/glbinding/source/logging.cpp
@@ -29,6 +29,11 @@ namespace glbinding
 namespace logging
 {
 
+void resize(const unsigned int newSize)
+{
+    g_buffer.resize(newSize);
+}
+
 void start()
 {
     auto now = std::chrono::system_clock::now();

--- a/source/glbinding/source/logging.cpp
+++ b/source/glbinding/source/logging.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <thread>
 
+#include "logging_private.h"
 #include "RingBuffer.h"
 
 namespace
@@ -31,7 +32,6 @@ namespace logging
 void start()
 {
     auto now = std::chrono::system_clock::now();
-
 
     auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
     auto ms = now_ms.count() % 1000;
@@ -112,18 +112,6 @@ void pause()
 void resume()
 {
     addCallbackMask(CallbackMask::Logging);
-}
-
-void log(bool enable)
-{
-    if (enable)
-    {
-        start();
-    }
-    else
-    {
-        stop();
-    }
 }
 
 void log(FunctionCall * call)

--- a/source/glbinding/source/logging.cpp
+++ b/source/glbinding/source/logging.cpp
@@ -128,11 +128,19 @@ void log(bool enable)
 
 void log(FunctionCall * call)
 {
-    delete g_buffer.nextHead();
+    bool available = false;
+    auto next = g_buffer.nextHead(available);
 
-    while(!g_buffer.push(call))
+    while (!available)
     {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        next = g_buffer.nextHead(available);
     }
+
+    assert(!g_buffer.isFull());
+
+    delete next;
+    g_buffer.push(call);
 }
 
 TailIdentifier addTail()

--- a/source/glbinding/source/logging.cpp
+++ b/source/glbinding/source/logging.cpp
@@ -49,10 +49,10 @@ void start(const std::string & filepath)
 void startExcept(const std::set<std::string> & blackList)
 {
     auto filepath = getStandardFilepath();
-    start(filepath);
+    startExcept(filepath, blackList);
 }
 
-void start(const std::string & filepath, const std::set<std::string> & blackList)
+void startExcept(const std::string & filepath, const std::set<std::string> & blackList)
 {
     addCallbackMaskExcept(CallbackMask::Logging, blackList);
     startWriter(filepath);

--- a/source/glbinding/source/logging.cpp
+++ b/source/glbinding/source/logging.cpp
@@ -92,6 +92,8 @@ void start(const std::string & filepath)
 
 void stop()
 {
+    removeCallbackMask(CallbackMask::Logging);
+
     g_stop = true;
     std::unique_lock<std::mutex> locker(g_lockfinish);
 
@@ -100,8 +102,6 @@ void stop()
     {
         g_finishcheck.wait(locker);
     }
-
-    removeCallbackMask(CallbackMask::Logging);
 }
 
 void pause()

--- a/source/glbinding/source/logging.cpp
+++ b/source/glbinding/source/logging.cpp
@@ -12,7 +12,7 @@
 
 namespace
 {
-    const unsigned int LOG_BUFFER_SIZE = 1000000;
+    const unsigned int LOG_BUFFER_SIZE = 5000;
 
     std::atomic<bool> g_stop{false};
     std::atomic<bool> g_persisted{false};
@@ -83,7 +83,7 @@ void start(const std::string & filepath)
 
             logfile.flush();
 
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
 
         logfile.close();
@@ -126,7 +126,7 @@ void log(FunctionCall * call)
 
     while (!available)
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
         next = g_buffer.nextHead(available);
     }
 

--- a/source/glbinding/source/logging_private.h
+++ b/source/glbinding/source/logging_private.h
@@ -8,8 +8,10 @@ namespace glbinding
 
 namespace logging
 {
-    using BufferType = FunctionCall*;
+    void startWriter(const std::string & filepath);
+    const std::string getStandardFilepath();
 
+    using BufferType = FunctionCall*;
     using TailIdentifier = unsigned int;
     TailIdentifier addTail();
     void removeTail(TailIdentifier);

--- a/source/glbinding/source/logging_private.h
+++ b/source/glbinding/source/logging_private.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <glbinding/callbacks.h>
+
+
+namespace glbinding 
+{
+
+namespace logging
+{
+    using BufferType = FunctionCall*;
+
+    using TailIdentifier = unsigned int;
+    TailIdentifier addTail();
+    void removeTail(TailIdentifier);
+    const std::vector<BufferType>::const_iterator cbegin(TailIdentifier key);
+    bool valid(TailIdentifier key, const std::vector<BufferType>::const_iterator & it);
+    const std::vector<BufferType>::const_iterator next(TailIdentifier key, const std::vector<BufferType>::const_iterator & it);
+    unsigned int size(TailIdentifier key);
+}
+
+
+} // namespace glbinding

--- a/source/tests/glbinding-test/RingBuffer_test.cpp
+++ b/source/tests/glbinding-test/RingBuffer_test.cpp
@@ -296,5 +296,18 @@ TEST_F(RingBuffer_test, MultiThreadedTest2)
     EXPECT_EQ(0u, buffer.size());
 }
 
+TEST_F(RingBuffer_test, ResizeTest)
+{
+
+    RingBuffer<int> buffer(10);
+
+    EXPECT_EQ(0u, buffer.size());
+    EXPECT_EQ(10u, buffer.maxSize());
+
+    buffer.resize(20u);
+
+    EXPECT_EQ(0u, buffer.size());
+    EXPECT_EQ(20u, buffer.maxSize());
+}
 
 


### PR DESCRIPTION
This pull requests fixes some of the existing logging issues.
* Fix possible memory leak in nextHead
* Directly stop logging, when stop() is called
* Restructure logging into public and private API (not 100% sure if everything is done correctly)
* The log buffer can now be resized and the initial log buffer size is set to 1000 (this slows down the performance for me in comparison but I guess this strongly depends on the system)
* Make logging configurable by adding a startExcept method

This is only tested on Mac OS X so far.