### PR TITLE
Fix cygwin compilation

### DIFF
--- a/cmake/PlatformLinuxGCC.cmake
+++ b/cmake/PlatformLinuxGCC.cmake
@@ -44,12 +44,15 @@ set(LINUX_COMPILE_FLAGS
       -Wall         # -> 
       -Wextra       # -> 
       -Werror       # ->
-      -fPIC         # -> use position independent code
       -Wreturn-type 
     # -Werror=return-type -> missing returns in functions and methods are handled as errors which stops the compilation
       -Wcast-align  # ->
     # -Wshadow      # -> e.g. when a parameter is named like a member, too many warnings, disabled for now
 )
+
+if(NOT CYGWIN)
+  set(LINUX_COMPILE_FLAGS ${LINUX_COMPILE_FLAGS} -fPIC) # -> use position independent code
+endif()
 
 set(DEFAULT_COMPILE_FLAGS
     ${LINUX_COMPILE_FLAGS}

--- a/source/glbinding/source/RingBuffer.hpp
+++ b/source/glbinding/source/RingBuffer.hpp
@@ -4,6 +4,7 @@
 #include <thread>
 #include <iterator>
 #include <cassert>
+#include <complex>
 
 #include "RingBuffer.h"
 

--- a/source/glbinding/source/RingBuffer.hpp
+++ b/source/glbinding/source/RingBuffer.hpp
@@ -4,7 +4,7 @@
 #include <thread>
 #include <iterator>
 #include <cassert>
-#include <complex>
+#include <cmath>
 
 #include "RingBuffer.h"
 


### PR DESCRIPTION
-fPIC is ignored on windows and gcc generates a warning if used under
cygwin. I've added a check in the setup files to exclude it if cygwin is
detected. Also, gcc under cygwin was complaining about std::abs being
undefined, so I added the appropriate header.