### PR TITLE
Disable -Wshadow for MinGW

### DIFF
--- a/cmake/PlatformWindowsGCC.cmake
+++ b/cmake/PlatformWindowsGCC.cmake
@@ -53,7 +53,7 @@ set(MINGW_COMPILE_FLAGS
       -Wconversion 
     # -Werror=return-type -> missing returns in functions and methods are handled as errors which stops the compilation
       -Wcast-align  # ->
-      -Wshadow      # -> e.g. when a parameter is named like a member, too many warnings, disabled for now
+    # -Wshadow      # -> e.g. when a parameter is named like a member, too many warnings, disabled for now
 )
 
 set(DEFAULT_COMPILE_FLAGS


### PR DESCRIPTION
I forgot it in my previous issue, but MinGW also chokes on -Wshadow which finds shadowed names in logging.cpp. Since the shadowing is pretty harmless, I thought that the best solution would be to disable -Wshadow for MinGW (which is what the comments already imply anyway).